### PR TITLE
Patch 5

### DIFF
--- a/jquery.ua.js
+++ b/jquery.ua.js
@@ -99,6 +99,7 @@
                 { name: 'ipod',   versionSearch: 'iphone os ', flags: ['ios'] },
                 { name: 'iphone', versionSearch: 'iphone os ', flags: ['ios'] }, // iphone must be tested before mac
                 { name: 'mac', versionSearch: 'os x ', versionNames: [
+                    { number: '10.15', name: 'catalina' },
                     { number: '10.14', name: 'mojave' },
                     { number: '10.13', name: 'highsierra' },
                     { number: '10.12', name: 'sierra' },

--- a/jquery.ua.js
+++ b/jquery.ua.js
@@ -117,6 +117,7 @@
                     { number: '10.0', name: 'cheetah' }
                 ]},
                 { name: 'android', versionSearch: 'android ', versionNames: [ // android must be tested before linux
+                    { number: '10.', name: '10' },
                     { number: '9.', name: 'pie' },
                     { number: '8.', name: 'oreo' },
                     { number: '7.', name: 'nougat' },


### PR DESCRIPTION
Adding macOS Catalina and Android 10. 

Android 10 was going to be called "Queen Cake" but Google has stopped using letter and dessert names to distinguish between the various Android versions. Therefor I added it as:

`{ number: '10.', name: '10' },`

But, maybe you could also use:

`{ number: '10.', name: 'queencake' },`

However, since Google stopped using dessert names publicly it might not be clear if future versions _(ie. Android R etc.)_ will ever get a name or if it will just be called "11".